### PR TITLE
Small Build System and Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,30 @@ Inspired by the work of [Patrick Hund](https://github.com/pahund).
 ### Make it run
 
 ```
-$ npm install
-$ npm build
-$ npm start
+npm install
+npm run build
+npm start
 ```
+
 Check your browser at [localhost:3000](localhost:3000)
 
 ### Development 
+
+For local development, you run two watch jobs in parallel, one for
+rebuilding the client-side JavaScript code when client-side scripts are changed,
+and one for rebuilding the server-side JavaScript code when server-side scripts
+are changed.
+
+Run these two commands in two separate terminal windows or tabs – client:
+
 ```
-$ npm run dev:start
+npm run dev:client
 ```
+
+Server:
+
+```
+npm run dev:server
+```
+
 Check your browser at [localhost:3000](localhost:3000)

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "webpack --progress --config config/webpack.js",
     "start": "node build/server.bundle.js",
-    "dev:server": "webpack --config config/webpack.server.js --watch",
-    "dev:client": "webpack --config config/webpack.client.js --watch"
+    "dev:server": "webpack --config config/webpack/webpack.server.js --watch",
+    "dev:client": "webpack --config config/webpack/webpack.client.js --watch"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/server/bloodyRender.js
+++ b/src/server/bloodyRender.js
@@ -16,6 +16,7 @@ const bloodyRender = (component) => {
     </head>
     <body ${helmet.bodyAttributes.toString()}>
       <div id="app">${markup}</div>
+      <h1>HI</h1>
       <script src="/public/app.bundle.js"></script>
     </body>
   </html>`


### PR DESCRIPTION
* The commands `npm run dev:client` and `npm run dev:server` did not work because of an incorrect path in [package.json](package.json); this was fixed
* The documentation about how to run dev builds in [README.md](README.md) was incorrect / unclear; this was fixed